### PR TITLE
Entries Generator

### DIFF
--- a/backend/src/db/entriesGenerator.js
+++ b/backend/src/db/entriesGenerator.js
@@ -1,0 +1,75 @@
+const moment = require("moment")
+
+// Random generator to create daily entries for 3 users from (current date) to (current date + n days)
+function generator(n) {
+    let entries = []
+    let currentDate = moment()
+
+    // Got this straight off of MDN, random number between two values (e.g. 4 - 10) rather than 0 - max
+    function getRandomArbitrary(min, max) {
+        return Math.random() * (max - min) + min;
+    }
+
+
+    for (let i = 0; i < n; i++) {
+        const tomorrow = moment(currentDate).add(1, 'days')
+        const formattedTomorrow = moment(tomorrow).format("YYYY-MM-DD")
+
+        // If desired, person_id value can be set to:
+        // Math.floor(Math.random() * (total number of users))
+        // in order to generate entries for every user
+        const generatedEntry1 = {
+            person_id: 1,
+            date: formattedTomorrow,
+            sleep_duration: Math.round(getRandomArbitrary(3, 12)),
+            quality_of_sleep: Math.round(getRandomArbitrary(1, 10)),
+            physical_activity_level: Math.floor(Math.random() * 10),
+            stress_level: Math.floor(Math.random() * 10),
+            bmi_category: "Normal",
+            blood_pressure: `${Math.round(getRandomArbitrary(80, 160))}/${Math.round(getRandomArbitrary(50, 90))}`,
+            heart_rate: Math.round(getRandomArbitrary(40, 120)),
+            daily_steps: Math.round(getRandomArbitrary(500, 20000)),
+            sleep_disorder: "None"
+        }
+
+        const generatedEntry2 = {
+            person_id: 2,
+            date: formattedTomorrow,
+            sleep_duration: Math.round(getRandomArbitrary(3, 12)),
+            quality_of_sleep: Math.round(getRandomArbitrary(1, 10)),
+            physical_activity_level: Math.floor(Math.random() * 10),
+            stress_level: Math.floor(Math.random() * 10),
+            bmi_category: "Overweight",
+            blood_pressure: `${Math.round(getRandomArbitrary(100, 180))}/${Math.round(getRandomArbitrary(60, 90))}`,
+            heart_rate: Math.round(getRandomArbitrary(60, 140)),
+            daily_steps: Math.round(getRandomArbitrary(500, 10000)),
+            sleep_disorder: "None"
+        }
+
+        const generatedEntry3 = {
+            person_id: 3,
+            date: formattedTomorrow,
+            sleep_duration: Math.round(getRandomArbitrary(3, 12)),
+            quality_of_sleep: Math.round(getRandomArbitrary(1, 10)),
+            physical_activity_level: Math.floor(Math.random() * 10),
+            stress_level: Math.floor(Math.random() * 10),
+            bmi_category: "Underweight",
+            blood_pressure: `${Math.round(getRandomArbitrary(80, 140))}/${Math.round(getRandomArbitrary(50, 80))}`,
+            heart_rate: Math.round(getRandomArbitrary(40, 120)),
+            daily_steps: Math.round(getRandomArbitrary(500, 25000)),
+            sleep_disorder: "None"
+        }
+
+        entries.push(generatedEntry1)
+        entries.push(generatedEntry2)
+        entries.push(generatedEntry3)
+
+        currentDate = tomorrow
+    }
+
+    return entries
+}
+
+module.exports = {
+    generator,
+}

--- a/backend/src/db/entriesGenerator.js
+++ b/backend/src/db/entriesGenerator.js
@@ -5,6 +5,9 @@ function generator(n) {
     let entries = []
     let currentDate = moment()
 
+    // Start 30 days in the past
+    let workingDate = currentDate.subtract(30, 'days')
+
     // Got this straight off of MDN, random number between two values (e.g. 4 - 10) rather than 0 - max
     function getRandomArbitrary(min, max) {
         return Math.random() * (max - min) + min;
@@ -12,7 +15,7 @@ function generator(n) {
 
 
     for (let i = 0; i < n; i++) {
-        const tomorrow = moment(currentDate).add(1, 'days')
+        const tomorrow = moment(workingDate).add(1, 'days')
         const formattedTomorrow = moment(tomorrow).format("YYYY-MM-DD")
 
         // If desired, person_id value can be set to:
@@ -64,7 +67,7 @@ function generator(n) {
         entries.push(generatedEntry2)
         entries.push(generatedEntry3)
 
-        currentDate = tomorrow
+        workingDate = tomorrow
     }
 
     return entries

--- a/backend/src/db/seeds/01-entriesData.js
+++ b/backend/src/db/seeds/01-entriesData.js
@@ -1,10 +1,15 @@
+/*
+Not using this data anymore but will still keep it around if we wanna use it for tests or something
 const entriesData = require("./01-entriesData.json")
+*/
+const { generator } = require("../entriesGenerator")
+const randomGeneratedEntries = generator(500)
 
 exports.seed = function (knex) {
     return knex
         .raw("TRUNCATE TABLE entries RESTART IDENTITY CASCADE")
         .then(function () {
-            return knex("entries").insert(entriesData)
+            return knex("entries").insert(randomGeneratedEntries)
         })
         .catch(function (error) {
             console.error("Error seeding data:", error)

--- a/backend/src/entries/entries.router.js
+++ b/backend/src/entries/entries.router.js
@@ -17,6 +17,7 @@ router
     .delete(controller.deleteEntry)
     .all(methodNotAllowed)
 
+// Special route just to get kpi averages over the past thirty days for a specific user
 router
     .route("/user/averages/:personId")
     .get(controller.readLastMonthAverages)

--- a/backend/src/entries/entries.service.js
+++ b/backend/src/entries/entries.service.js
@@ -20,6 +20,7 @@ function create(newEntryData) {
 function readPerson(personId) {
     return knex("entries")
         .where({ person_id: personId })
+        .andWhere('date', '<=', knex.raw('CURRENT_DATE'))
         .orderBy("date", "desc")
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,6 @@
         "@testing-library/user-event": "^13.5.0",
         "flowbite": "^2.3.0",
         "flowbite-react": "^0.7.2",
-        "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
@@ -18167,13 +18166,6 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "license": "MIT"
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/morgan": {
       "version": "1.9.1",
@@ -36387,9 +36379,6 @@
     },
     "mkdirp-classic": {
       "version": "0.5.3"
-    },
-    "moment": {
-      "version": "2.30.1"
     },
     "morgan": {
       "version": "1.9.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "flowbite": "^2.3.0",
         "flowbite-react": "^0.7.2",
+        "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
@@ -18166,6 +18167,14 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/morgan": {
       "version": "1.9.1",
@@ -36379,6 +36388,11 @@
     },
     "mkdirp-classic": {
       "version": "0.5.3"
+    },
+    "moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "morgan": {
       "version": "1.9.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,6 @@
     "@testing-library/user-event": "^13.5.0",
     "flowbite": "^2.3.0",
     "flowbite-react": "^0.7.2",
-    "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "flowbite": "^2.3.0",
     "flowbite-react": "^0.7.2",
+    "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",


### PR DESCRIPTION
I made one of those seed generators like I made for my restaurant reservation system.

This one is a little more straightforward and a little more actually random, it starts at the current date minus 30 days and creates one entry per day for users 1, 2, and 3 up to whatever number of days is input in the function arg. Pretty much all the values for each entry are individually randomized. I seeded it out to sometime next year.

I had to make some adjustments to include the generator in the seed file and to the readPerson function in entries.service so it wouldn't load up all these future entries when we visit the "Past Reports" page.

Don't forget to 'npm i' to make sure moment is installed on the frontend and the backend