### PR TITLE
Entries Table Scroll Snap

### DIFF
--- a/frontend/src/Dashboard/UserRecordsTable/UserActivitiesList.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserActivitiesList.jsx
@@ -10,7 +10,7 @@ export default function UserActivitiesList({ userId, entries, setEntries }) {
             <>
                 {entries.map((entry) => (
                     <Table.Row
-                        className="bg-white dark:border-gray-700 dark:bg-gray-800"
+                        className="bg-white dark:border-gray-700 dark:bg-gray-800 snap-start"
                         key={entry.entry_id}
                     >
                         <ActivityCard

--- a/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
@@ -48,8 +48,8 @@ export default function UserRecordsTable({ userId, entries, setEntries }) {
 
     return (
         <>
-            <div className="overflow-x-auto max-h-96 md:max-h-full overflow-y-auto snap-y">
-                <Table hoverable className='snap-mandatory'>
+            <div className="overflow-x-auto max-h-96 md:max-h-full overflow-y-auto snap-y snap-mandatory">
+                <Table hoverable>
                     <Table.Head className="sticky top-0 bg-white z-10">
                         <Table.HeadCell>
                             <div className="flex flex-row gap-1">

--- a/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
@@ -48,8 +48,8 @@ export default function UserRecordsTable({ userId, entries, setEntries }) {
 
     return (
         <>
-            <div className="overflow-x-auto max-h-96 md:max-h-full overflow-y-auto">
-                <Table hoverable>
+            <div className="overflow-x-auto max-h-96 md:max-h-full overflow-y-auto snap-y">
+                <Table hoverable className='snap-mandatory'>
                     <Table.Head className="sticky top-0 bg-white z-10">
                         <Table.HeadCell>
                             <div className="flex flex-row gap-1">


### PR DESCRIPTION
Used tailwind classes to get entries table to snap (to top - "snap-start") on scroll.

I'm gonna immediately merge this pull request, just making the request for documentation