### PR TITLE
Employees Table Scroll Snap, Table Style Tweaks

### DIFF
--- a/frontend/src/Dashboard/AdminEmployeesTable/AdminEmployeesTable.jsx
+++ b/frontend/src/Dashboard/AdminEmployeesTable/AdminEmployeesTable.jsx
@@ -70,27 +70,35 @@ export default function AdminEmployeesTable({ employees, openModal }) {
                 <Table hoverable>
                     <Table.Head className="sticky top-0 bg-white z-10">
                         <Table.HeadCell>
-                                <button aria-label='Sort by Username' className="flex flex-row gap-1" onClick={() => onSort("username")}>
+                                <button aria-label='Sort by Username' className="flex flex-row items-center gap-1" onClick={() => onSort("username")}>
                                     <p>USER</p>
-                                    {getSortIcon("username")}
+                                    <div>
+                                        {getSortIcon("username")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label='Sort by Age' className="flex flex-row gap-1" onClick={() => onSort("age")}>
+                                <button aria-label='Sort by Age' className="flex flex-row items-center gap-1" onClick={() => onSort("age")}>
                                     <p>AGE</p>
-                                    {getSortIcon("age")}
+                                    <div>
+                                        {getSortIcon("age")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label='Sort by Occupation' className="flex flex-row gap-1" onClick={() => onSort("occupation")}>
+                                <button aria-label='Sort by Occupation' className="flex flex-row items-center gap-1" onClick={() => onSort("occupation")}>
                                     <p>OCCUPATION</p>
-                                    {getSortIcon("occupation")}
+                                    <div>
+                                        {getSortIcon("occupation")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label='Sort by Sleep Disorder' className="flex flex-row gap-1" onClick={() => onSort("sleep_disorder")}>
+                                <button aria-label='Sort by Sleep Disorder' className="flex flex-row items-center gap-1" onClick={() => onSort("sleep_disorder")}>
                                 <p>SLEEP DISORDER</p>
+                                <div>
                                     {getSortIcon("sleep_disorder")}
+                                </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>

--- a/frontend/src/Dashboard/AdminEmployeesTable/AdminEmployeesTable.jsx
+++ b/frontend/src/Dashboard/AdminEmployeesTable/AdminEmployeesTable.jsx
@@ -59,16 +59,15 @@ export default function AdminEmployeesTable({ employees, openModal }) {
 
     return (
         <>
-            <div className="overflow-x-auto max-h-96 md:max-h-full md:w-full overflow-y-auto">
+        <div className="flex flex-col">
+            <div className="ps-3 py-3">
+                <SearchBar
+                    employees={employees}
+                    setFilteredEmployees={setFilteredEmployees}
+                />
+            </div>
+            <div className="overflow-x-auto max-h-96 md:max-h-full md:w-full overflow-y-auto snap-y snap-mandatory scroll-py-14">
                 <Table hoverable>
-                    <Table.Head>
-                        <Table.HeadCell colSpan={6}>
-                            <SearchBar
-                                employees={employees}
-                                setFilteredEmployees={setFilteredEmployees}
-                            />
-                        </Table.HeadCell>
-                    </Table.Head>
                     <Table.Head className="sticky top-0 bg-white z-10">
                         <Table.HeadCell>
                             <div className="flex flex-row gap-1">
@@ -118,6 +117,7 @@ export default function AdminEmployeesTable({ employees, openModal }) {
                     </Table.Body>
                 </Table>
             </div>
+        </div>
         </>
     )
 }

--- a/frontend/src/Dashboard/AdminEmployeesTable/EmployeesListNew.jsx
+++ b/frontend/src/Dashboard/AdminEmployeesTable/EmployeesListNew.jsx
@@ -9,7 +9,7 @@ export default function EmployeesList({ employees, setEmployees, openModal }) {
             <>
                 {employees.map((employee) => (
                     <Table.Row
-                        className="bg-white dark:border-gray-700 dark:bg-gray-800"
+                        className="bg-white dark:border-gray-700 dark:bg-gray-800 snap-start"
                         key={employee.person_id}
                     >
                         <EmployeeCardNew

--- a/frontend/src/Dashboard/AdminEmployeesTable/SearchBar.jsx
+++ b/frontend/src/Dashboard/AdminEmployeesTable/SearchBar.jsx
@@ -4,14 +4,14 @@ export default function SearchBar({ employees, setFilteredEmployees }) {
     const [searchString, setSearchString] = useState("")
 
     const filterEmployees = useCallback((value) => {
-        return employees.filter((employee) => employee.username.startsWith(value))
+        return employees.filter((employee) => employee.username.toLowerCase().startsWith(value.toLowerCase()))
     }, [employees])
 
     // Run of the mill text field change handler with the addition of a simple search function executed on each letter typed
     const handleChange = (event) => {
         const { value } = event.target
         setSearchString(value)
-        setFilteredEmployees(filterEmployees(value.toLowerCase()))
+        setFilteredEmployees(filterEmployees(value))
     }
 
     return (
@@ -23,8 +23,8 @@ export default function SearchBar({ employees, setFilteredEmployees }) {
                 id="search"
                 value={searchString}
                 onChange={handleChange}
-                placeholder="Search"
-                className="leading-tight"
+                placeholder="Search Employees"
+                className="leading-tight rounded-sm"
             />
         </form>
         </>

--- a/frontend/src/Dashboard/Dashboard.jsx
+++ b/frontend/src/Dashboard/Dashboard.jsx
@@ -104,7 +104,7 @@ export default function AdminHome() {
                     ) : (
                         <UserProgressCharts averages={averages} goals={goals}/>
                     )}
-                    <div className="flex flex-col md:flex-row  w-full mx-auto mt-5 max-w-5xl md:max-h-[75vh] rounded-lg shadow-md overflow-hidden ">
+                    <div className="flex flex-col md:flex-row  w-full mx-auto mt-5 max-w-5xl min-h-[50vh] md:max-h-[75vh] rounded-lg shadow-md overflow-hidden ">
                         <DashboardSidebar
                             openModal={openModal}
                             userIsAdmin={user.admin}

--- a/frontend/src/Dashboard/UserRecordsTable/UserActivitiesList.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserActivitiesList.jsx
@@ -10,7 +10,7 @@ export default function UserActivitiesList({ userId, entries, setEntries }) {
             <>
                 {entries.map((entry) => (
                     <Table.Row
-                        className="bg-white dark:border-gray-700 dark:bg-gray-800 snap-start"
+                        className="text-center bg-white dark:border-gray-700 dark:bg-gray-800 snap-start"
                         key={entry.entry_id}
                     >
                         <ActivityCard

--- a/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
@@ -92,11 +92,24 @@ export default function UserRecordsTable({ userId, entries, setEntries }) {
                         </Table.HeadCell>
                     </Table.Head>
                     <Table.Body className="divide-y scroller">
-                        <UserActivitiesList
-                            userId={userId}
-                            entries={sortedEntries}
-                            setEntries={setEntries}
-                        />
+                        {entries.length ? 
+                            <UserActivitiesList
+                                userId={userId}
+                                entries={sortedEntries}
+                                setEntries={setEntries}
+                            />
+                            :
+                            <Table.Row>
+                                <Table.Cell colSpan="6">
+                                    
+                            <h3
+                                className="text-center text-xl p-20 span-6"
+                            >
+                                You Haven't Made Any Entries Yet
+                            </h3>
+                            </Table.Cell>
+                            </Table.Row>
+                        }
                     </Table.Body>
                 </Table>
             </div>

--- a/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
@@ -52,39 +52,51 @@ export default function UserRecordsTable({ userId, entries, setEntries }) {
                 <Table hoverable>
                     <Table.Head className="sticky top-0 bg-white z-10">
                         <Table.HeadCell>
-                                <button aria-label="Sort by Date"className="flex flex-row gap-1" onClick={() => onSort("date")}>
+                                <button aria-label="Sort by Date"className="flex flex-row items-center gap-1" onClick={() => onSort("date")}>
                                     <p>DATE</p>
-                                    {getSortIcon("date")}
+                                    <div>
+                                        {getSortIcon("date")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label="Sort by Steps"className="flex flex-row gap-1" onClick={() => onSort("daily_steps")}>
+                                <button aria-label="Sort by Steps"className="flex flex-row items-center gap-1" onClick={() => onSort("daily_steps")}>
                                     <p>STEPS</p>
-                                    {getSortIcon("daily_steps")}
+                                    <div>
+                                        {getSortIcon("daily_steps")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label="Sort by Heart Rate"className="flex flex-row gap-1" onClick={() => onSort("heart_rate")}>
+                                <button aria-label="Sort by Heart Rate"className="flex flex-row items-center gap-1" onClick={() => onSort("heart_rate")}>
                                     <p>HEART RATE</p>
-                                    {getSortIcon("heart_rate")}
+                                    <div>
+                                        {getSortIcon("heart_rate")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label="Sort by BMI Category"className="flex flex-row gap-1" onClick={() => onSort("bmi_category")}>
-                                    <p>BMI CATEGORY</p> 
-                                    {getSortIcon("bmi_category")}
+                                <button aria-label="Sort by BMI Category"className="flex flex-row items-center gap-1" onClick={() => onSort("bmi_category")}>
+                                    <p>BMI CATEGORY</p>
+                                    <div>
+                                        {getSortIcon("bmi_category")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label="Sort by Stress Level"className="flex flex-row gap-1" onClick={() => onSort("stress_level")}>
+                                <button aria-label="Sort by Stress Level"className="flex flex-row items-center gap-1" onClick={() => onSort("stress_level")}>
                                     <p>STRESS LEVEL</p>
-                                    {getSortIcon("stress_level")}
+                                    <div>
+                                        {getSortIcon("stress_level")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>
-                                <button aria-label="Sort by Sleep Hours"className="flex flex-row gap-1" onClick={() => onSort("sleep_duration")}>
-                                <p>SLEEP HOURS</p>
-                                    {getSortIcon("sleep_duration")}
+                                <button aria-label="Sort by Sleep Hours"className="flex flex-row items-center gap-1" onClick={() => onSort("sleep_duration")}>
+                                    <p>SLEEP HOURS</p>
+                                    <div>
+                                        {getSortIcon("sleep_duration")}
+                                    </div>
                                 </button>
                         </Table.HeadCell>
                         <Table.HeadCell>

--- a/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
+++ b/frontend/src/Dashboard/UserRecordsTable/UserRecordsTable.jsx
@@ -48,7 +48,7 @@ export default function UserRecordsTable({ userId, entries, setEntries }) {
 
     return (
         <>
-            <div className="overflow-x-auto max-h-96 md:max-h-full overflow-y-auto snap-y snap-mandatory">
+            <div className="overflow-x-auto max-h-96 md:max-h-full overflow-y-auto snap-y snap-mandatory scroll-py-14">
                 <Table hoverable>
                     <Table.Head className="sticky top-0 bg-white z-10">
                         <Table.HeadCell>

--- a/frontend/src/Footer/Footer.jsx
+++ b/frontend/src/Footer/Footer.jsx
@@ -25,7 +25,7 @@ export default function Footer() {
                     '#accordion-collapse-heading-1 button'
                 ),
                 targetEl: document.querySelector('#accordion-collapse-body-1'),
-                active: true,
+                active: false,
             },
             {
                 id: 'accordion-collapse-heading-2',

--- a/frontend/src/LandingPage/CallToActionBlock.jsx
+++ b/frontend/src/LandingPage/CallToActionBlock.jsx
@@ -12,7 +12,7 @@ export default function CallToActionBlock() {
             <div className="py-3">
                 <Link
                     to="/register"
-                    className="button-light-blue text-xl md:text-base px-10 py-5 md:px-8 md:px-4"
+                    className="button-light-blue text-xl md:text-base px-10 py-5 md:px-8"
                 >
                     Get Started
                 </Link>


### PR DESCRIPTION
I'm stoked on the scroll snap thing it feels nice so I added it to the employees table too. Had to move some stuff around in the code to accomodate the search bar on that table. I'm not sure if you had a reason to only do this on the entries table and not the employees table so I'm going to leave this one up for your approval instead of just merging it into main like I did with my last pull request.

**Changes:**
- Added "scroll-py-14" padding to scroll snap when I realized the snap was hiding the first entry behind the table head
- Set up employees table scroll snap
- Moved SearchBar dom location (up out of the table) so it wouldn't disappear after scroll snap
- Some styling and cleaning code on SearchBar